### PR TITLE
Remove is uploaded file

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ $change = $image
 * Uses `exif_imagetype()` method to get the **real** `mime/image` type,
 * Checks if image type exists in the expected types ie. `array('jpg', 'png', 'gif', 'jpeg')`
 * Checks `getimagesize();` to see if the image has a valid width/height measurable in pixels.
-* Uses `is_uploaded_file()` to check for a secure upload HTTP Post method, (extra security check).
 
 
 #### Todo

--- a/src/bulletproof.php
+++ b/src/bulletproof.php
@@ -708,22 +708,14 @@ class BulletProof
         $this->applyShrink($fileToUpload["tmp_name"], $fileToUpload["tmp_name"]);
         $this->applyCrop($fileToUpload["tmp_name"], $fileToUpload["tmp_name"]);
 
-        // Security check, to see if file was uploaded with HTTP_POST 
-        $checkSafeUpload = $this->isUploadedFile($fileToUpload["tmp_name"]);
-
         // Upload the file
         $moveUploadedFile = $this->moveUploadedFile($fileToUpload["tmp_name"], $this->uploadDir . "/" . $newFileName);
 
-        if ($checkSafeUpload && $moveUploadedFile) {
+        if ($moveUploadedFile) {
             return $this->uploadDir . "/" . $newFileName; 
         }else{
             throw new ImageUploaderException(" File could not be uploaded. Unknown error occurred. ");
         }
-    }
-
-    public function isUploadedFile($file)
-    {
-        return is_uploaded_file($file);
     }
 
     public function moveUploadedFile($uploaded_file, $new_file) {


### PR DESCRIPTION
The current implementation of `is_uploaded_file()` is insecure, as it moves the uploaded file regardless of what the check says. It only errors out if it fails, but the file has already been moved at this point.

Plus, calling `is_uploaded_file()` is redundant when using `move_uploaded_file()`, as it does the exact same check before moving the file.

Therefore, I suggest removing it altogether. It just adds unnecessary noise. It does not make anything more secure.

`is_uploaded_file()`:
```c
PHP_FUNCTION(is_uploaded_file)
{
	// ...

	if (!SG(rfc1867_uploaded_files)) {
		RETURN_FALSE;
	}

	// ...

	if (zend_hash_str_exists(SG(rfc1867_uploaded_files), path, path_len)) {
		RETURN_TRUE;
	} else {
		RETURN_FALSE;
	}
}
```

`move_uploaded_file()`:
```c
PHP_FUNCTION(move_uploaded_file)
{
	// ...

	if (!SG(rfc1867_uploaded_files)) {
		RETURN_FALSE;
	}

    // ...

    if (!zend_hash_str_exists(SG(rfc1867_uploaded_files), path, path_len)) {
		RETURN_FALSE;
	}

    // ...
}
```