### PR TITLE
Changed minimum PHP requirement to PHP 5.4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0"
     },
     "require-dev":{
      "phpunit/phpunit":"3.7.*"


### PR DESCRIPTION
* BulletProof uses short array syntax introduced with PHP 5.4
* Issue #41 mentioned the issues with PHP 5.3