### PR TITLE
Fixed imageMimes array

### DIFF
--- a/src/bulletproof.php
+++ b/src/bulletproof.php
@@ -71,8 +71,8 @@ class Image implements \ArrayAccess
      */
     protected $imageMimes = array(
         1 => "gif", "jpeg", "png", "swf", "psd",
-        "bmp", "tiff", "jpc", "jp2", "jpx",
-        "jb2", "swc", "iff", "wbmp", "xmb", "ico"
+        "bmp", "tiff", "tiff", "jpc", "jp2", "jpx",
+        "jb2", "swc", "iff", "wbmp", "xbm", "ico"
     );
 
     /**


### PR DESCRIPTION
Hi,
first of all thank you for this library, i really appreciate it a lot and used it in my project. During my debugging i've noticed a bug and this pull request is the fix.
Following the imagetype constants reference on php.net (http://php.net/manual/en/function.exif-imagetype.php#refsect1-function.exif-imagetype-constants) value 8 is also a tiff mime type.
I've also fixed the misspelled 'xbm' string (previously "xmb").

Thank you :)