### PR TITLE
Added getError method

### DIFF
--- a/src/bulletproof.php
+++ b/src/bulletproof.php
@@ -316,6 +316,15 @@ class Image implements \ArrayAccess
     }
 
     /**
+     * Returns error string or false if no errors occurred
+     *
+     * @return string|bool
+     */
+    public function getError(){
+        return $this->error != "" ? $this->error : false;
+    }
+
+    /**
      * Checks for the common upload errors
      *
      * @param $e int error constant


### PR DESCRIPTION
Hi again,
this is only a little enhancement if you like it: during debug i had some problems figuring out the exact problem, so i've created this little method that returns the error string (or false if no error occurred). It can also be useful to check the status of the upload and return the proper error message in a script.

In the readme.md is specified you can use $image['error'], but this solution is more polished due to the private nature or error attribute.

Hope this help!