### PR TITLE
fix: Alpha channel now stay fine (not converted to black color)

### DIFF
--- a/src/utils/func.image-crop.php
+++ b/src/utils/func.image-crop.php
@@ -41,18 +41,20 @@ namespace Bulletproof;
     }
 
     $temp = imagecreatetruecolor($newWidth, $newHeight);
-            imagecopyresampled(
-                $temp,
-                $imageCreate,
-                0,
-                0,
-                $widthTrim,
-                $heightTrim,
-                $newWidth,
-                $newHeight,
-                $newWidth,
-                $newHeight
-            );
+    imageAlphaBlending($temp, false);
+    imageSaveAlpha($temp, true);
+    imagecopyresampled(
+        $temp,
+        $imageCreate,
+        0,
+        0,
+        $widthTrim,
+        $heightTrim,
+        $newWidth,
+        $newHeight,
+        $newWidth,
+        $newHeight
+    );
 
 
     if (!$temp) {


### PR DESCRIPTION
GD2 converts alpha to black color by blending with background (which is default black), so png images has lost they alpha channel. To prevent it we must turn off blending (by  imageAlphaBlending($temp, false); ) and save alpha channel (by imageSaveAlpha($temp, true); )
