### PR TITLE
getimagesize() failure

### DIFF
--- a/src/bulletproof.php
+++ b/src/bulletproof.php
@@ -392,9 +392,8 @@ class Image implements \ArrayAccess
     protected function validateImageSize(){
         if (@getimagesize($this->_files["tmp_name"])) {
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
 
     /**

--- a/src/bulletproof.php
+++ b/src/bulletproof.php
@@ -384,6 +384,18 @@ class Image implements \ArrayAccess
         return $errors[$e];
     }
 
+    /**
+     * Checks if the image size, of the uploaded file is available
+     * If it returns false, the file is mostly certainly, not an image.
+     * @return bool
+     */
+    protected function validateImageSize(){
+        if ($data = @getimagesize($this->_files["tmp_name"])) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 
     /**
      * This methods validates and uploads the image
@@ -402,6 +414,13 @@ class Image implements \ArrayAccess
             return null;
         }
 
+        /* Check if the image size is ascertainable */
+        if ($this->validateImageSize() === false){
+            $ext = implode(", ", $image->mimeTypes);
+            $image->error = sprintf($this->error_messages['mime_type'], $ext);
+            return null;
+        }
+        
         /* initialize image properties */
         $image->name     = $image->getName();
         $image->width    = $image->getWidth();

--- a/src/bulletproof.php
+++ b/src/bulletproof.php
@@ -390,7 +390,7 @@ class Image implements \ArrayAccess
      * @return bool
      */
     protected function validateImageSize(){
-        if ($data = @getimagesize($this->_files["tmp_name"])) {
+        if (@getimagesize($this->_files["tmp_name"])) {
             return true;
         } else {
             return false;
@@ -420,7 +420,7 @@ class Image implements \ArrayAccess
             $image->error = sprintf($this->error_messages['mime_type'], $ext);
             return null;
         }
-        
+
         /* initialize image properties */
         $image->name     = $image->getName();
         $image->width    = $image->getWidth();


### PR DESCRIPTION
If getimagesize() fails, couse a user uploaded a none image file, a php E_NOTICE is thrown.
I added validateImageSize() to be able to output a custom error message, instead of throwing a E_NOTICE
It is used in upload().
If it returns false, the error message "mimeTypes" in upload() will be set and upload() returns null.