### PR TITLE
Added option to set quality for JPGs and compression level for PNGs

### DIFF
--- a/src/utils/func.image-resize.php
+++ b/src/utils/func.image-resize.php
@@ -17,27 +17,43 @@
 namespace Bulletproof\Utils;
 
 /*
- * Variable quality sets what quality should be used for JPEG or what compression should be used for PNG. See example.
  *
- * Example:
+ * @param      string      $image        Path to the image
+ * @param      string      $mimeType     The mime type of the image
+ * @param      integer     $imgWidth     The original image width
+ * @param      integer     $imgHeight    The original image height
+ * @param      integer     $newWidth     The new image width (to be resized to)
+ * @param      integer     $newHeight    The new image height (to be resized to)
+ * @param      boolean     $ratio        Whether to keep the ratio or no
+ * @param      boolean     $upsize       Whether to allow upsizing of the image or no
+ * @param      boolean     $cropToSize   Whether to crop image to size or no. If set to true $ratio is ignored.
+ * @param      array       $quality      Sets what quality should be used for
+ *                                       JPEG or what compression should be used
+ *                                       for PNG. See following example: *
+ *                                              array(
+ *                                                   'jpg' => array(
+ *                                                                  'orig'     => true,  // (bool) whether to use same quality as original image (requires ImageMagick)
+ *                                                                  'fallback' => 80,    // (int)  fallback if original image quality can not be detected or is not set. Accepted values are 1-100
+ *                                                                  'max'      => 85,    // (int)  Maximal quality, if detected quality is more than this value, than this will be used. Accepted values are 1-100
+ *                                                                  'min'      => 60     // (int)  Minimal quality, if detected quality is less than this value, than this will be used. Accepted values are 1-100
+ *                                                                  ),
+ *                                                   'png' => 9 // (int) PNG compression level. Accepted values are 0-9. Default is zlib's default which is currently ( 11/2018 ) equal to 6
+ *                                                  );
  *
- * array(
- *       'jpg' => array(
- *                      'orig'     => true,  // (bool) whether to use same quality as original image (requires ImageMagick)
- *                      'fallback' => 80,    // (int)  fallback if original image quality can not be detected or is not set. Accepted values are 1-100
- *                      'max'      => 85,    // (int)  Maximal quality, if detected quality is more than this value, than this will be used. Accepted values are 1-100
- *                      'min'      => 60     // (int)  Minimal quality, if detected quality is less than this value, than this will be used. Accepted values are 1-100
- *                      ),
- *       'png' => 9 // (int) PNG compression level. Accepted values are 0-9. Default is zlib's default which is currently ( 11/2018 ) equal to 6
- *      );
+ *                                       Any of the values can be left out. See following example:
+ *                                               array( 'jpg' => array( 'fallback' => 80 ) ) // this will set JPG quality to 80 on JPGs
  *
- * Any of the values can be left out.
+ * @param      string      $destination  Accepts either folder path or file.
+ *                                       Script can handle both relative and
+ *                                       absolute paths. Folder path needs to
+ *                                       end with '/' (forward slash). If left empty (or set to false) it will overwrite original image
  *
- * Example:
- * array( 'jpg' => array( 'fallback' => 80 ) ) // this will set JPG quality to 80 on JPGs
+ * @throws     \Exception  (description)
+ *
+ * @return     boolean     True on success false on failure
  *
  */
-function resize($image, $mimeType, $imgWidth, $imgHeight, $newWidth, $newHeight, $ratio = false, $upsize = true, $cropToSize = false, $quality = array())
+function resize($image, $mimeType, $imgWidth, $imgHeight, $newWidth, $newHeight, $ratio = false, $upsize = true, $cropToSize = false, $quality = array(), $destination = false)
 {
     // Checks whether image cropping is enabled
     if ($cropToSize) {
@@ -151,6 +167,27 @@ function resize($image, $mimeType, $imgWidth, $imgHeight, $newWidth, $newHeight,
         $src_h
     );
 
+    if ($destination !== false) {  // checks if was destination provided
+        if(substr( $destination, -1 ) == '/' ) { // check whether prowided destination was folder or file.
+            $create = !is_dir($destination) ? @mkdir($destination, 0777, true) : true; // if it was folder, it will crtete it if needed
+            if ($create) {
+                $path_parts = pathinfo($image);
+                $destination = $destination . $path_parts['basename'];
+            } else {
+                return false; // TODO: throw error/exception
+            }
+        }
+
+    } else {
+        $destination = $image;
+    }
+
+    $path_parts = pathinfo($destination);
+    $create = !is_dir($path_parts['dirname'].'/') ? @mkdir($path_parts['dirname'].'/', 0777, true) : true;
+    if (!$create) {
+        return false; // TODO: throw error/exception
+    }
+
     switch ($mimeType) {
         case "jpeg":
         case "jpg":
@@ -175,7 +212,7 @@ function resize($image, $mimeType, $imgWidth, $imgHeight, $newWidth, $newHeight,
                     $q = $quality['jpg']['min'];
                 }
             }
-            imagejpeg($tmp, $image, $q );
+            return imagejpeg($tmp, $destination, $q );
             break;
         case "png":
             if ((!empty($quality['png'])) AND ( (int) $quality['png'] ) AND ( $quality['png'] >= -1 ) AND ( $quality['png'] <=9 ) ) {
@@ -183,10 +220,10 @@ function resize($image, $mimeType, $imgWidth, $imgHeight, $newWidth, $newHeight,
             } else {
                 $q = -1; // -1 is zlib's default value which is currently ( 11/2018 ) equal to 6
             }
-            imagepng($tmp, $image, $q );
+            return imagepng($tmp, $destination, $q );
             break;
         case "gif":
-            imagegif($tmp, $image);
+            return imagegif($tmp, $destination);
             break;
         default:
             throw new \Exception(" Only jpg, jpeg, png and gif files can be resized ");

--- a/src/utils/func.image-resize.php
+++ b/src/utils/func.image-resize.php
@@ -47,13 +47,14 @@ namespace Bulletproof\Utils;
  *                                       Script can handle both relative and
  *                                       absolute paths. Folder path needs to
  *                                       end with '/' (forward slash). If left empty (or set to false) it will overwrite original image
+ * @param      integer     $permission   The permission for destination folder (if it will be created by script)
  *
  * @throws     \Exception  (description)
  *
  * @return     boolean     True on success false on failure
  *
  */
-function resize($image, $mimeType, $imgWidth, $imgHeight, $newWidth, $newHeight, $ratio = false, $upsize = true, $cropToSize = false, $quality = array(), $destination = false)
+function resize($image, $mimeType, $imgWidth, $imgHeight, $newWidth, $newHeight, $ratio = false, $upsize = true, $cropToSize = false, $quality = array(), $destination = false, $permission = 0755)
 {
     // Checks whether image cropping is enabled
     if ($cropToSize) {
@@ -169,7 +170,7 @@ function resize($image, $mimeType, $imgWidth, $imgHeight, $newWidth, $newHeight,
 
     if ($destination !== false) {  // checks if was destination provided
         if(substr( $destination, -1 ) == '/' ) { // check whether prowided destination was folder or file.
-            $create = !is_dir($destination) ? @mkdir($destination, 0777, true) : true; // if it was folder, it will crtete it if needed
+            $create = !is_dir($destination) ? @mkdir($destination, $permission, true) : true; // if it was folder, it will crtete it if needed
             if ($create) {
                 $path_parts = pathinfo($image);
                 $destination = $destination . $path_parts['basename'];
@@ -183,7 +184,7 @@ function resize($image, $mimeType, $imgWidth, $imgHeight, $newWidth, $newHeight,
     }
 
     $path_parts = pathinfo($destination);
-    $create = !is_dir($path_parts['dirname'].'/') ? @mkdir($path_parts['dirname'].'/', 0777, true) : true;
+    $create = !is_dir($path_parts['dirname'].'/') ? @mkdir($path_parts['dirname'].'/', $permission, true) : true;
     if (!$create) {
         return false; // TODO: throw error/exception
     }


### PR DESCRIPTION
User will get chance to set quality for JPGs including using same quality as original image - this feature requires ImageMagick, but if this is not installed fallback value is used (no error shown). User can at the same time set minimal and maximal allowed quality.

Added option to set compression level for PNGs.

Everything stays backwards compatible.

